### PR TITLE
Fix wrong download speed format (Mb/s to MB/s)

### DIFF
--- a/CRD/Utils/HLS/HLSDownloader.cs
+++ b/CRD/Utils/HLS/HLSDownloader.cs
@@ -262,7 +262,7 @@ public class HlsDownloader{
                 File.WriteAllText($"{fn}.resume", resumeDataJson);
 
                 // Log progress
-                Console.WriteLine($"{_data.Parts.Completed} of {totalSeg} parts downloaded [{dataLog.Percent}%] ({FormatTime(dataLog.Time)} | {dataLog.DownloadSpeed / 1000000.0:F2}Mb/s)");
+                Console.WriteLine($"{_data.Parts.Completed} of {totalSeg} parts downloaded [{dataLog.Percent}%] ({FormatTime(dataLog.Time)} | {dataLog.DownloadSpeed / 1000000.0:F2}MB/s)");
 
                 _currentEpMeta.DownloadProgress = new DownloadProgress(){
                     IsDownloading = true,

--- a/CRD/ViewModels/DownloadsPageViewModel.cs
+++ b/CRD/ViewModels/DownloadsPageViewModel.cs
@@ -127,7 +127,7 @@ public partial class DownloadItemModel : INotifyPropertyChanged{
         Done = epMeta.DownloadProgress.Done;
         Percent = epMeta.DownloadProgress.Percent;
         Time = "Estimated Time: " + TimeSpan.FromSeconds(epMeta.DownloadProgress.Time).ToString(@"hh\:mm\:ss");
-        DownloadSpeed = $"{epMeta.DownloadProgress.DownloadSpeed / 1000000.0:F2}Mb/s";
+        DownloadSpeed = $"{epMeta.DownloadProgress.DownloadSpeed / 1000000.0:F2}MB/s";
         Paused = epMeta.Paused || !isDownloading && !epMeta.Paused;
         DoingWhat = epMeta.Paused ? "Paused" :
             Done ? (epMeta.DownloadProgress.Doing != string.Empty ? epMeta.DownloadProgress.Doing : "Done") :
@@ -192,7 +192,7 @@ public partial class DownloadItemModel : INotifyPropertyChanged{
         Done = epMeta.DownloadProgress.Done;
         Percent = epMeta.DownloadProgress.Percent;
         Time = "Estimated Time: " + TimeSpan.FromSeconds(epMeta.DownloadProgress.Time).ToString(@"hh\:mm\:ss");
-        DownloadSpeed = $"{epMeta.DownloadProgress.DownloadSpeed / 1000000.0:F2}Mb/s";
+        DownloadSpeed = $"{epMeta.DownloadProgress.DownloadSpeed / 1000000.0:F2}MB/s";
 
         Paused = epMeta.Paused || !isDownloading && !epMeta.Paused;
         DoingWhat = epMeta.Paused ? "Paused" :


### PR DESCRIPTION
Small little nitpick, but:

I recently upgraded to faster internet, about 7Gbps (= 7000Mbps) down- and upload. Which is besides the point, but how I noticed this small mistake:

The main download page in the app shows the download speed unit as megaBITS per second, indicated by the small "b" in "Mb/s". However, the speed (the displayed number) is actually reported in megaBYTES per second (MB/s), which is 8 times smaller than the megabit per second figure (since there are 8 bits in a byte). This screenshot demonstrates the problem:

<img width="450" height="256" alt="image" src="https://github.com/user-attachments/assets/4f8355d8-fcf4-4521-abfc-36dc59462dea" />

As one can see, I am downloading at 5.7 Gbps, which is equal to 5700 Mbps. The download speed is reported as approx. 625 Mb/s, whereas it is actually around 710 MB/s (5700 divided by 8) or 5700 Mb/s. The small discrepancy between 625 and 710 is not the issue here, it's the fact that the speed is shown as Mb/s instead of MB/s.

Internet download speeds are commonly shown in Mbps (Mb/s, Megabits per second) figures (for example speedtests and Steam game downloads) whereas file transfer speeds are almost always shown in MBps (MB/s, Megabytes per second). This PR just changes the strings from Mb/s to MB/s, but my suggestion would be to either show both units or, even better, to add a toggle to switch between the two displayed figures. I would be able to do this by myself as I have some C# experience, but since there is no provided .csproj, .sln or whatever is required for an Avalonia project file, I'm not sure how I would compile the app according to your standards to test the change. Maybe you would be able to provide a project file or, alternatively, compilation instructions?